### PR TITLE
Use Language ID instead of locale for extraction

### DIFF
--- a/CrowdinProvider.php
+++ b/CrowdinProvider.php
@@ -109,6 +109,13 @@ final class CrowdinProvider implements ProviderInterface
         $translatorBag = new TranslatorBag();
         $responses = [];
 
+        $localeLanguageIdMap = [];
+        foreach ($this->listLanguages($locales) as $language) {
+            if (in_array($language['data']['locale'], $locales)) {
+                $localeLanguageIdMap[$language['data']['locale']] = $language['data']['id'];
+            }
+        }
+
         foreach ($domains as $domain) {
             $fileId = $this->getFileIdByDomain($fileList, $domain);
 
@@ -118,7 +125,7 @@ final class CrowdinProvider implements ProviderInterface
 
             foreach ($locales as $locale) {
                 if ($locale !== $this->defaultLocale) {
-                    $response = $this->exportProjectTranslations($locale, $fileId);
+                    $response = $this->exportProjectTranslations($localeLanguageIdMap[$locale], $fileId);
                 } else {
                     $response = $this->downloadSourceFile($fileId);
                 }
@@ -328,6 +335,25 @@ final class CrowdinProvider implements ProviderInterface
          * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.projects.files.download.get (Crowdin Enterprise API)
          */
         return $this->client->request('GET', sprintf('files/%d/download', $fileId));
+    }
+
+    private function listLanguages(): array
+    {
+        /**
+         * @see https://developer.crowdin.com/api/v2/#operation/api.languages.getMany (Crowdin API)
+         * @see https://developer.crowdin.com/enterprise/api/v2/#operation/api.languages.getMany (Crowdin Enterprise API)
+         */
+        $response = $this->client->request('GET', '../../languages', [
+            'query' => [
+                'limit' => 500
+            ]
+        ]);
+
+        if (200 !== $response->getStatusCode()) {
+            throw new ProviderException(sprintf('Unable to list set languages.'), $response);
+        }
+
+        return $response->toArray()['data'];
     }
 
     private function listStrings(int $fileId, int $limit, int $offset): array


### PR DESCRIPTION
Hello,

this is a request I need to consult with. We're using locales to communicate with Crowdin. The pull from Crowdin fails, because if for example 'de-DE' locale is passed as a locale, it does not find the translation. Problem is, that the parameter for language needs to be language ID, not locale. Therefore the request fails.

I propose a fix, but it might break if somebody uses language shortcodes instead full locale representation. Might need a fallback in that case.